### PR TITLE
Added API Endpoint to Search by Combined User First, Middle, and Last Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # IntelliJ
 .idea/
 
+# Eclipse
+.classpath
+.project
+.settings/
+
 # Target
 target/
 

--- a/src/main/java/com/bravo/user/controller/UserController.java
+++ b/src/main/java/com/bravo/user/controller/UserController.java
@@ -43,10 +43,33 @@ public class UserController {
     return userService.create(request);
   }
 
-  @GetMapping(value = "/retrieve/{id}")
+  @GetMapping(value = "/retrieveId/{id}")
   @ResponseBody
-  public UserReadDto retrieve(@PathVariable String id){
-    return userService.retrieve(id);
+  public UserReadDto retrieveById(@PathVariable String id){
+    return userService.retrieveById(id);
+  }
+  
+  /**
+   * Retrieves a paginated list of users whose first, middle, and last names match the specified name.
+   * The name to search may contain negation ("!") or wildcard ("*" or "%") characters
+   * 
+   * @param name Name to find - should contain first, middle, and last name without space
+   * @param page Page number to retrieve
+   * @param size Size of the page to retrieve
+   * @param response {@linkplain HttpServletResponse}
+   * @return List of {@linkplain UserReadDto}s with combined first, middle, and last names that match the search criteria
+   */
+  @GetMapping(value = "/retrieveName/{name}")
+  @ResponseBody
+  public List<UserReadDto> retrieveByName(
+	  final @PathVariable String name,
+	  final @RequestParam(required = false) Integer page,
+	  final @RequestParam(required = false) Integer size,
+	  final HttpServletResponse response) {
+	  
+	  userValidator.validateName(name);
+	  final PageRequest pageRequest = PageUtil.createPageRequest(page, size);
+	  return userService.retrieveByName(name, pageRequest, response);
   }
 
   @PostMapping(value = "/retrieve")

--- a/src/main/java/com/bravo/user/dao/specification/AbstractSpecification.java
+++ b/src/main/java/com/bravo/user/dao/specification/AbstractSpecification.java
@@ -86,9 +86,10 @@ public abstract class AbstractSpecification<T> implements Specification<T> {
         inClause.add(s.toLowerCase());
         continue;
       }
-      final String targetValue = (isNot ? s.substring(1) : s).toLowerCase();
+      String targetValue = (isNot ? s.substring(1) : s).toLowerCase();
       Predicate predicate;
       if(isLike){
+    	targetValue = targetValue.replace("*", "%"); // "like" queries must use "%"
         predicate = criteriaBuilder.like(targetPath, targetValue);
       } else {
         predicate = criteriaBuilder.equal(targetPath, targetValue);

--- a/src/main/java/com/bravo/user/model/filter/UserFilter.java
+++ b/src/main/java/com/bravo/user/model/filter/UserFilter.java
@@ -11,5 +11,6 @@ public class UserFilter {
   private Set<String> firstNames;
   private Set<String> lastNames;
   private Set<String> middleNames;
+  private Set<String> fullNames;
   private DateFilter<LocalDateTime> dateFilter;
 }

--- a/src/main/java/com/bravo/user/service/UserService.java
+++ b/src/main/java/com/bravo/user/service/UserService.java
@@ -12,7 +12,6 @@ import com.bravo.user.utility.PageUtil;
 import com.bravo.user.utility.ValidatorUtil;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
@@ -41,7 +40,13 @@ public class UserService {
     return resourceMapper.convertUser(user);
   }
 
-  public UserReadDto retrieveById(final String id){
+  /**
+   * Retrieves a single user by ID
+   * 
+   * @param id ID to find
+   * @return {@linkplain UserReadDto} with matching ID, if it exists
+   */
+  public UserReadDto retrieve(final String id){
     Optional<User> optional = userRepository.findById(id);
     User user = getUser(id, optional);
 
@@ -50,29 +55,13 @@ public class UserService {
   }
   
   /**
-   * Retrieves a paginated list of users whose combined first, middle, and last names matches the specified name.
+   * Retrieves a paginated list of users using the criteria specified in the given filter.
    * 
-   * @param name Name to find with format [firstName][middleName][lastName] and no space. May contain negation ("!") or
-   * wildcard ("*"/"%") characters.
+   * @param filter {@linkplain UserFilter} Containing search criteria to filter on
    * @param pageRequest {@linkplain PageRequest} containing pagination parameters
    * @param response {@linkplain HttpServletResponse} in which to store page information
-   * @return List of {@linkplain UserReadDto}s whose combined names match the search name criteria
+   * @return List of {@linkplain UserReadDto}s that meet the filter criteria
    */
-  public List<UserReadDto> retrieveByName(
-	  final String name,
-	  final PageRequest pageRequest,
-	  final HttpServletResponse response) {
-	  
-	  final UserFilter filter = new UserFilter();
-	  filter.setFullNames(Set.of(name));
-	  final Page<User> userPage = userRepository.findAll(new UserSpecification(filter), pageRequest);
-	  final List<UserReadDto> users = resourceMapper.convertUsers(userPage.getContent());
-	  LOGGER.info("found {} user(s)", users.size());
-	  
-	  PageUtil.updatePageHeaders(response, userPage, pageRequest);
-	  return users;
-  }
-
   public List<UserReadDto> retrieve(
       final UserFilter filter,
       final PageRequest pageRequest,

--- a/src/main/java/com/bravo/user/validator/UserValidator.java
+++ b/src/main/java/com/bravo/user/validator/UserValidator.java
@@ -3,6 +3,9 @@ package com.bravo.user.validator;
 import com.bravo.user.exception.BadRequestException;
 import com.bravo.user.model.dto.UserSaveDto;
 import com.bravo.user.utility.ValidatorUtil;
+
+import java.util.regex.Pattern;
+
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
@@ -13,6 +16,20 @@ public class UserValidator extends CrudValidator {
     if(ValidatorUtil.isInvalid(id)){
       throw new BadRequestException("'id' is required");
     }
+  }
+  
+  /**
+   * Validates a user name to ensure it is not null, not empty, and does not contain space, numbers, or special characters.
+   * 
+   * @param name User name to validate
+   * @throws BadRequestException if the name is invalid
+   */
+  public void validateName(String name) {
+	  Pattern pattern = Pattern.compile("[^a-z*%!]", Pattern.CASE_INSENSITIVE);
+	  if (ValidatorUtil.isInvalid(name) || pattern.matcher(name).find()) {
+		  throw new BadRequestException("'name' is required and should not contain space, numbers, or special characters"
+		  		+ "other than '*', '%', and '!'");
+	  }
   }
 
   @Override

--- a/src/main/java/com/bravo/user/validator/UserValidator.java
+++ b/src/main/java/com/bravo/user/validator/UserValidator.java
@@ -11,6 +11,8 @@ import org.springframework.validation.Errors;
 
 @Component
 public class UserValidator extends CrudValidator {
+	
+  private static final Pattern NAME_VALIDATOR_PATTERN =  Pattern.compile("[^a-z*%!]", Pattern.CASE_INSENSITIVE);
 
   public void validateId(String id){
     if(ValidatorUtil.isInvalid(id)){
@@ -25,8 +27,7 @@ public class UserValidator extends CrudValidator {
    * @throws BadRequestException if the name is invalid
    */
   public void validateName(String name) {
-	  Pattern pattern = Pattern.compile("[^a-z*%!]", Pattern.CASE_INSENSITIVE);
-	  if (ValidatorUtil.isInvalid(name) || pattern.matcher(name).find()) {
+	  if (ValidatorUtil.isInvalid(name) || NAME_VALIDATOR_PATTERN.matcher(name).find()) {
 		  throw new BadRequestException("'name' is required and should not contain space, numbers, or special characters"
 		  		+ "other than '*', '%', and '!'");
 	  }

--- a/src/test/java/com/bravo/user/config/AppConfigTest.java
+++ b/src/test/java/com/bravo/user/config/AppConfigTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -16,6 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @TestPropertySource(properties = {
     "server.port=9090",
 })
+@SpringBootTest
 public class AppConfigTest {
 
   @Autowired


### PR DESCRIPTION
* Added Controller API endpoint to search for users by combined first, middle, and last names.  For example:
`http://localhost:9999/user/retrieve?name=JackPool`

* Updated User filter and specification to add ability to filter by combined first, middle, and last names. The existing logic in `AbstractSpecification::applyStringFilter` is still used to process negation("!") and wildcard ("*"/"%") characters.  Therefore, the new API `name` query parameter may contain these operators.  For example:
`http://localhost:9999/user/retrieve?name=!*Wagon`

* Added validator method to validate user name, ensuring it contains only valid characters and no space.

Ad-hoc tested with Chrome 91.0 and Postman.  Junit tests are still WIP...