### PR TITLE
Add payment controller stack.

### DIFF
--- a/src/main/java/com/bravo/user/controller/PaymentController.java
+++ b/src/main/java/com/bravo/user/controller/PaymentController.java
@@ -1,0 +1,40 @@
+package com.bravo.user.controller;
+
+import com.bravo.user.annotation.SwaggerController;
+import com.bravo.user.exception.BadRequestException;
+import com.bravo.user.model.dto.PaymentDto;
+import com.bravo.user.service.PaymentService;
+import com.bravo.user.validator.UserValidator;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@RequestMapping(value = "/payment")
+@SwaggerController
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    private final UserValidator userValidator;
+
+    public PaymentController(PaymentService paymentService, UserValidator userValidator) {
+        this.paymentService = paymentService;
+        this.userValidator = userValidator;
+    }
+
+    @GetMapping(value = "/retrieve")
+    @ResponseBody
+    public List<PaymentDto> retrieve(
+            final @RequestParam(required = false) String userId
+    ) {
+        if (userId != null) {
+            userValidator.validateId(userId);
+            return paymentService.retrieveByUserId(userId);
+        } else {
+            throw new BadRequestException("'user id' is required!");
+        }
+    }
+
+}

--- a/src/main/java/com/bravo/user/dao/model/mapper/ResourceMapper.java
+++ b/src/main/java/com/bravo/user/dao/model/mapper/ResourceMapper.java
@@ -48,7 +48,7 @@ public class ResourceMapper {
   public PaymentDto convertPayment(final Payment payment){
     final String cardNumber = payment.getCardNumber();
     final PaymentDto dto = mapperFacade.map(payment, PaymentDto.class);
-    dto.setCardNumberLast4(cardNumber.substring(cardNumber.length() - 5));
+    dto.setCardNumberLast4(cardNumber.substring(cardNumber.length() - 4));
     return dto;
   }
 

--- a/src/main/java/com/bravo/user/dao/repository/PaymentRepository.java
+++ b/src/main/java/com/bravo/user/dao/repository/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.bravo.user.dao.repository;
+
+import com.bravo.user.dao.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, String>, JpaSpecificationExecutor<Payment> {
+
+    List<Payment> findByUserId(final String userId);
+
+}

--- a/src/main/java/com/bravo/user/service/PaymentService.java
+++ b/src/main/java/com/bravo/user/service/PaymentService.java
@@ -1,0 +1,33 @@
+package com.bravo.user.service;
+
+import com.bravo.user.dao.model.Payment;
+import com.bravo.user.dao.model.mapper.ResourceMapper;
+import com.bravo.user.dao.repository.PaymentRepository;
+import com.bravo.user.model.dto.PaymentDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PaymentService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PaymentService.class);
+
+    private final PaymentRepository paymentRepository;
+    private final ResourceMapper resourceMapper;
+
+    public PaymentService(PaymentRepository paymentRepository, ResourceMapper resourceMapper) {
+        this.paymentRepository = paymentRepository;
+        this.resourceMapper = resourceMapper;
+    }
+
+    public List<PaymentDto> retrieveByUserId(final String userId) {
+        //List<String> iterateUserIds = Arrays.asList(userId);
+        List<Payment> results = paymentRepository.findByUserId(userId);
+
+        LOGGER.info("found payments for user '{}'", userId);
+        return resourceMapper.convertPayments(results);
+    }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -648,3 +648,7 @@ insert into address (id, user_id, line1, line2, city, state, zip) values
 ('42f33d30-f3f8-4743-a94e-4db11fdb747d', '008a4215-0b1d-445e-b655-a964039cbb5a', '412 Maple St', null, 'Dowagiac', 'Michigan', '49047'),
 ('579872ec-46f8-46b5-b809-d0724d965f0e', '00963d9b-f884-485e-9455-fcf30c6ac379', '237 Mountain Ter', 'Apt 10', 'Odenville', 'Alabama', '35120'),
 ('95a983d0-ba0e-4f30-afb6-667d4724b253', '00963d9b-f884-485e-9455-fcf30c6ac379', '107 Annettes Ct', null, 'Aydlett', 'North Carolina', '27916');
+
+insert into payment (id, user_id, card_number, expiry_month, expiry_year) values
+('PMT1414004','fd9e22ef-20f1-4e1b-9f9e-3139fd13fa85','1111222233334444', 6,26 ),
+('PMT1414005','fd9e22ef-20f1-4e1b-9f9e-3139fd13fa85','5555666677778888', 8,28 );

--- a/src/test/java/com/bravo/user/controller/PaymentControllerTest.java
+++ b/src/test/java/com/bravo/user/controller/PaymentControllerTest.java
@@ -1,0 +1,97 @@
+package com.bravo.user.controller;
+
+import com.bravo.user.App;
+import com.bravo.user.model.dto.PaymentDto;
+import com.bravo.user.service.PaymentService;
+import com.bravo.user.validator.UserValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ContextConfiguration(classes = {App.class})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest()
+@AutoConfigureMockMvc
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    private final UserValidator userValidator = new UserValidator();
+
+    private List<PaymentDto> payments;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.payments = createPaymentsDto();
+    }
+
+    @Test
+    void getRetrieveWithUserId() throws Exception {
+        when(paymentService.retrieveByUserId(anyString())).thenReturn(payments);
+
+        final ResultActions result = this.mockMvc
+                .perform(get("/payment/retrieve?userId=" + "userId"))
+                .andExpect(status().isOk());
+
+        for (int i = 0; i < 2; i++) {
+            result.andExpect(jsonPath(String.format("$[%d].id", i)).value(payments.get(i).getId()));
+            result.andExpect(jsonPath(String.format("$[%d].cardNumberLast4", i)).value(payments.get(i).getCardNumberLast4()));
+        }
+
+        verify(paymentService).retrieveByUserId(eq("userId"));
+    }
+
+    @Test
+    void getRetrieveWithIdEmpty() throws Exception {
+        this.mockMvc.perform(get("/payment/retrieve?userId="))
+                .andExpect(status().isBadRequest());
+    }
+
+    private List<PaymentDto> createPaymentsDto() {
+
+        List<PaymentDto> payments = new ArrayList<>();
+
+        final PaymentDto payment1 = new PaymentDto();
+        payment1.setId("1234");
+        payment1.setCardNumberLast4("1111");
+        payment1.setExpiryYear(2026);
+        payment1.setExpiryMonth(4);
+        payment1.setUpdated(LocalDateTime.now());
+
+        final PaymentDto payment2 = new PaymentDto();
+        payment2.setId("5678");
+        payment2.setCardNumberLast4("2222");
+        payment2.setExpiryYear(2036);
+        payment2.setExpiryMonth(6);
+        payment2.setUpdated(LocalDateTime.now());
+
+        payments.add(payment1);
+        payments.add(payment2);
+
+        return payments;
+    }
+}

--- a/src/test/java/com/bravo/user/dao/model/mapper/ResourceMapperTest.java
+++ b/src/test/java/com/bravo/user/dao/model/mapper/ResourceMapperTest.java
@@ -1,6 +1,15 @@
 package com.bravo.user.dao.model.mapper;
 
+import com.bravo.user.App;
+import com.bravo.user.MapperArgConverter;
+import com.bravo.user.dao.model.Address;
+import com.bravo.user.dao.model.Payment;
+import com.bravo.user.dao.model.User;
+import com.bravo.user.model.dto.AddressDto;
+import com.bravo.user.model.dto.PaymentDto;
+import com.bravo.user.model.dto.UserReadDto;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -17,13 +26,17 @@ import com.bravo.user.dao.model.User;
 import com.bravo.user.model.dto.AddressDto;
 import com.bravo.user.model.dto.UserReadDto;
 
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 @ContextConfiguration(classes = {App.class})
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 class ResourceMapperTest {
 
-  @Autowired
-  private ResourceMapper resourceMapper;
+    @Autowired
+    private ResourceMapper resourceMapper;
 
   @ParameterizedTest
   @CsvFileSource(
@@ -48,4 +61,17 @@ class ResourceMapperTest {
 			@ConvertWith(MapperArgConverter.class) AddressDto addressDto) {
 		Assertions.assertEquals(addressDto, resourceMapper.convertAddress(address));
 	}
+
+    @Test
+    public void convertPaymentTest() {
+        final Payment payment = new Payment();
+        payment.setId("765");
+        payment.setCardNumber("1111222233334444");
+        payment.setExpiryYear(2026);
+        payment.setExpiryMonth(4);
+        payment.setUpdated(LocalDateTime.now());
+
+        PaymentDto paymentDto = resourceMapper.convertPayment(payment);
+        assertEquals(paymentDto.getCardNumberLast4(), "4444");
+    }
 }

--- a/src/test/java/com/bravo/user/service/PaymentServiceTest.java
+++ b/src/test/java/com/bravo/user/service/PaymentServiceTest.java
@@ -1,0 +1,74 @@
+package com.bravo.user.service;
+
+import com.bravo.user.App;
+import com.bravo.user.dao.model.Payment;
+import com.bravo.user.dao.repository.PaymentRepository;
+import com.bravo.user.model.dto.PaymentDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.when;
+
+@ContextConfiguration(classes = {App.class})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class PaymentServiceTest {
+
+    @Autowired
+    private PaymentService paymentService;
+    @MockBean
+    private PaymentRepository paymentRepository;
+
+    private List<Payment> payments;
+
+    @BeforeEach
+    public void beforeEach() {
+        this.payments = createPayments();
+    }
+
+    @Test
+    public void retrieveByUserIdName() {
+        when(paymentRepository.findByUserId(anyString())).thenReturn(payments);
+        List<PaymentDto> paymentDtos = paymentService.retrieveByUserId("userId");
+
+        assertEquals(paymentDtos.size(), 2);
+        assertEquals(paymentDtos.get(1).getCardNumberLast4(), "8888");
+
+    }
+
+    private List<Payment> createPayments() {
+
+        List<Payment> payments = new ArrayList<>();
+
+        final Payment payment1 = new Payment();
+        payment1.setId("444");
+        payment1.setCardNumber("1111222233334444");
+        payment1.setExpiryYear(2026);
+        payment1.setExpiryMonth(4);
+        payment1.setUpdated(LocalDateTime.now());
+
+        final Payment payment2 = new Payment();
+        payment2.setId("444");
+        payment2.setCardNumber("5555666677778888");
+        payment2.setExpiryYear(2036);
+        payment2.setExpiryMonth(6);
+        payment2.setUpdated(LocalDateTime.now());
+
+        payments.add(payment1);
+        payments.add(payment2);
+
+        return payments;
+    }
+}


### PR DESCRIPTION
This pull request attempts to fulfill the following [Trello ](https://trello.com/c/avi8pE7N/13-0013-backend-add-payment-method-retrieve-api) requirements:

- Create Payment Controller
- Create Payment Retrieve GET API
- Create Payment Service
- Create Payment Repository
- Ensure Retrieve API is Working 
- Write jUnit to Test Implementation
- Raise PR into Original Repository when done (this is for

API Working Screentshot (from Swagger UI):
![image](https://user-images.githubusercontent.com/104106203/164357916-f98b638a-3cb0-4d28-a5dd-b7e4e591bfc8.png)

Tests - JUnit and Maven:
![image](https://user-images.githubusercontent.com/104106203/164358143-8d5fc20c-21eb-4a62-b1e2-249537d1b7b9.png)
![image](https://user-images.githubusercontent.com/104106203/164359105-6b8d9163-5bf5-4a06-8600-ad0bc63ba2b2.png)


Notes:
-Did not add a full set of validation for the incoming user id, but at least had a check for blank.  This could be improved. 
-There seemed to be a defect in the ResourceMapper, it would pump out the last five characters of a credit card, I switched it to four and added a test for that. (Unless I am misunderstanding the data.)
-Added test data to the sql test file.
-Ran the IntelliJ remove imports/reformat -- but did not run format on exiting updated files just new.
-Confirmed the maven and the IDE build steps, as this can be an issue on some code bases but not this.

